### PR TITLE
docs(readme)  Update Usage Examples to Match Current Library Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ First, add `egui-map-view` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-egui-map-view = "0.2.1" # Replace with the latest version
+egui-map-view = "0.2.2" # Replace with the latest version
 ```
 
 Then, create a `Map` widget and add it to your `egui` UI.
 
 ```rust
 use eframe::egui;
-use egui_map::{Map, config::OpenStreetMapConfig};
+use egui_map_view::{Map, config::OpenStreetMapConfig};
 
 struct MyApp {
     map: Map,
@@ -57,18 +57,18 @@ impl eframe::App for MyApp {
             .frame(egui::Frame::NONE)
             .show(ctx, |ui| {
                 // Add the map widget to the UI.
-                ui.add(&mut self.map);
+                ui.add_sized(ui.available_size_before_wrap(), &mut self.map);
             });
 
         // A window to show map information and controls.
         egui::Window::new("Map Info").show(ctx, |ui| {
             ui.label(format!("Zoom: {}", self.map.zoom));
-            ui.label(format!("Center: {:.4}, {:.4}", self.map.center.1, self.map.center.0));
+            ui.label(format!("Center: {:.4}, {:.4}", self.map.center.lat, self.map.center.lon));
             
             ui.separator();
 
-            if let Some((lon, lat)) = self.map.mouse_pos {
-                ui.label(format!("Mouse: {:.4}, {:.4}", lat, lon));
+            if let Some(pos) = self.map.mouse_pos {
+                ui.label(format!("Mouse: {:.4}, {:.4}", pos.lat, pos.lon));
             } else {
                 ui.label("Mouse: N/A");
             }
@@ -88,8 +88,8 @@ The map's appearance and behavior are controlled by a type that implements the `
 You can implement the `MapConfig` trait to use any other tile server. For example, here's how you could create a configuration for a custom provider:
 
 ```rust
-use egui_map::config::MapConfig;
-use egui_map::TileId;
+use egui_map_view::config::MapConfig;
+use egui_map_view::TileId;
 
 struct MyCustomProvider {
     // ... any fields your provider needs, like an API key.
@@ -101,9 +101,14 @@ impl MapConfig for MyCustomProvider {
         format!("https://my-tile-server.com/{}/{}/{}.png", tile_id.z, tile_id.x, tile_id.y)
     }
 
-    fn attribution(&self) -> &str {
+    fn attribution(&self) -> Option<&String> {
         // Return the attribution string required by your provider.
-        "My Custom Tiles © Me"
+        Some("My Custom Tiles © Me".into())
+    }
+
+    fn attribution_url(&self) -> Option<&String> {
+        // Return the attribution URL to be linked from the attribution text.
+        Some("https://my-tile-server.com".into())   
     }
 
     // You can also override default_center() and default_zoom().


### PR DESCRIPTION
#### **Summary**
This PR updates the `README.md` usage examples to reflect the latest design and API structure of the library.  
The previous examples referenced outdated module paths and configuration trait signatures that no longer align with the current version of the crate.

---

#### **Key Changes**
- **Dependencies section:**
  - Removed outdated duplicate `egui-map-view = "0.2.1"` entry.
  - Updated to reference the latest crate version (`0.2.2`).

- **Usage example:**
  - Replaced all instances of `egui_map` with the new `egui_map_view` module path.
  - Fixed coordinate display examples 

- **Configuration example:**
  - Updated `MapConfig` trait implementation to reflect the new method signatures:

