### PR TITLE
Implement UUID to layer elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "egui-map-view"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "earcutr",
  "eframe",
@@ -1216,6 +1216,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -1378,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1388,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -5149,6 +5150,7 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "egui-map-view"
 description = "An slippy map viewer for egui applications."
-version = "0.6.3"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/braincow/egui-map-view"
@@ -27,9 +27,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 earcutr = { version = "0.5.0", optional = true }
 geojson = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0.150", optional = true }
+uuid = { version = "1.23", features = ["v4", "serde"] }
 
 [dev-dependencies]
-env_logger = "0.11.10" # used for examples
+env_logger = "0.11.11" # used for examples
 serde_json = "1.0.150" # used for some tests
 rfd = "0.17.2"         # used for examples
 

--- a/examples/areas.rs
+++ b/examples/areas.rs
@@ -42,6 +42,7 @@ impl Default for MyApp {
             stroke: Stroke::new(2.0, Color32::from_rgb(255, 0, 0)),
             fill: Color32::from_rgba_unmultiplied(255, 0, 0, 50),
             fill_type: FillType::Hatching,
+            ..Default::default()
         });
 
         // Circle with solid fill
@@ -54,6 +55,7 @@ impl Default for MyApp {
             stroke: Stroke::new(2.0, Color32::from_rgb(0, 102, 255)),
             fill: Color32::from_rgba_unmultiplied(0, 102, 255, 50),
             fill_type: FillType::Solid,
+            ..Default::default()
         });
 
         // Rectangle with no fill (outline only)
@@ -67,6 +69,7 @@ impl Default for MyApp {
             stroke: Stroke::new(2.0, Color32::from_rgb(0, 180, 0)),
             fill: Color32::TRANSPARENT,
             fill_type: FillType::None,
+            ..Default::default()
         });
 
         // Rotated Ellipse with solid fill
@@ -81,6 +84,7 @@ impl Default for MyApp {
             stroke: Stroke::new(2.0, Color32::from_rgb(255, 165, 0)),
             fill: Color32::from_rgba_unmultiplied(255, 165, 0, 50),
             fill_type: FillType::Solid,
+            ..Default::default()
         });
 
         map.add_layer("areas", area_layer);
@@ -115,8 +119,8 @@ impl eframe::App for MyApp {
 
                     if area_layer.mode == AreaMode::ModifySelected {
                         ui.separator();
-                        if let Some(idx) = area_layer.selected_area {
-                            ui.label(format!("Selected Area Index: {idx}"));
+                        if let Some(id) = area_layer.selected_area {
+                            ui.label(format!("Selected Area ID: {id}"));
                             if ui.button("Clear Selection").clicked() {
                                 area_layer.selected_area = None;
                             }

--- a/examples/place_text.rs
+++ b/examples/place_text.rs
@@ -63,7 +63,7 @@ impl eframe::App for MyApp {
             if let Some(mut editing) = layer.editing.take() {
                 let mut open = true;
                 let mut should_commit = false;
-                let title = if editing.index.is_some() {
+                let title = if editing.id.is_some() {
                     "Edit Text"
                 } else {
                     "Add Text"

--- a/src/layers/area.rs
+++ b/src/layers/area.rs
@@ -25,6 +25,7 @@
 //!         stroke: Stroke::new(2.0, Color32::from_rgb(255, 0, 0)),
 //!         fill: Color32::from_rgba_unmultiplied(255, 0, 0, 50),
 //!         fill_type: FillType::Solid,
+//!         ..Default::default()
 //!     });
 //!     area_layer.mode = AreaMode::Modify;
 //!

--- a/src/layers/area/layer.rs
+++ b/src/layers/area/layer.rs
@@ -35,8 +35,8 @@ pub struct AreaLayer {
     pub opacity: f32,
 
     #[serde(skip)]
-    /// The index of the currently selected area. Only used when in `AreaMode::Selected`.
-    pub selected_area: Option<usize>,
+    /// The unique identifier of the currently selected area. Only used when in `AreaMode::ModifySelected`.
+    pub selected_area: Option<uuid::Uuid>,
 }
 
 impl Default for AreaLayer {
@@ -76,6 +76,25 @@ impl AreaLayer {
     pub fn areas_mut(&mut self) -> &mut Vec<Area> {
         &mut self.areas
     }
+
+    /// Finds an area in the layer by its ID.
+    pub fn find_area(&self, id: uuid::Uuid) -> Option<&Area> {
+        self.areas.iter().find(|a| a.id == id)
+    }
+
+    /// Finds an area in the layer by its ID and returns a mutable reference.
+    pub fn find_area_mut(&mut self, id: uuid::Uuid) -> Option<&mut Area> {
+        self.areas.iter_mut().find(|a| a.id == id)
+    }
+
+    /// Removes an area from the layer by its ID and returns it.
+    pub fn remove_area(&mut self, id: uuid::Uuid) -> Option<Area> {
+        if let Some(pos) = self.areas.iter().position(|a| a.id == id) {
+            Some(self.areas.remove(pos))
+        } else {
+            None
+        }
+    }
 }
 
 impl Layer for AreaLayer {
@@ -107,27 +126,31 @@ impl Layer for AreaLayer {
                     && let Some(pointer_pos) = response.interact_pointer_pos()
                 {
                     // Find if any area was clicked to select it.
-                    let clicked_area_idx =
+                    let clicked_area_id =
                         self.areas.iter().enumerate().rev().find_map(|(idx, area)| {
                             let contains_fill = area.contains(pointer_pos, projection);
                             let over_handle = self.find_object_at(pointer_pos, projection, Some(idx)).is_some();
                             let over_segment = self.find_line_segment_at(pointer_pos, projection, Some(idx)).is_some();
 
                             if contains_fill || over_handle || over_segment {
-                                Some(idx)
+                                Some(area.id)
                             } else {
                                 None
                             }
                         });
 
-                    if clicked_area_idx != self.selected_area {
-                        self.selected_area = clicked_area_idx;
+                    if clicked_area_id != self.selected_area {
+                        self.selected_area = clicked_area_id;
                         return true;
                     }
                 }
 
-                if let Some(selected_idx) = self.selected_area {
-                    self.handle_modify_input(response, projection, Some(selected_idx))
+                if let Some(selected_id) = self.selected_area {
+                    if let Some(selected_idx) = self.areas.iter().position(|a| a.id == selected_id) {
+                        self.handle_modify_input(response, projection, Some(selected_idx))
+                    } else {
+                        false
+                    }
                 } else {
                     false
                 }

--- a/src/layers/area/render.rs
+++ b/src/layers/area/render.rs
@@ -15,7 +15,7 @@ impl AreaLayer {
             // Draw polygon outline
             if screen_points.len() >= 3 {
                 let is_selected =
-                    self.mode == AreaMode::ModifySelected && self.selected_area == Some(area_idx);
+                    self.mode == AreaMode::ModifySelected && self.selected_area == Some(area.id);
                 let stroke = if is_selected {
                     Stroke {
                         width: area.stroke.width * 2.0,
@@ -90,7 +90,7 @@ impl AreaLayer {
 
             // Draw nodes only when in modify mode or if specifically selected
             let show_nodes = self.mode == AreaMode::Modify
-                || (self.mode == AreaMode::ModifySelected && self.selected_area == Some(area_idx));
+                || (self.mode == AreaMode::ModifySelected && self.selected_area == Some(area.id));
             if show_nodes {
                 let drag_fill = Color32::from_rgb(255, 140, 0); // High-contrast orange for active dragging
                 match &area.shape {

--- a/src/layers/area/tests.rs
+++ b/src/layers/area/tests.rs
@@ -35,6 +35,7 @@ fn area_layer_add_area() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     });
 
     assert_eq!(layer.areas.len(), 1);
@@ -52,6 +53,7 @@ fn circle_get_points_with_fixed_number() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     };
 
     let points = area.get_points(&projection);
@@ -78,6 +80,7 @@ fn find_object_at_polygon_node() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     });
 
     // Position is exactly on the node
@@ -113,6 +116,7 @@ fn area_layer_serde() {
         stroke: Stroke::new(1.0, Color32::RED),
         fill: Color32::BLUE,
         fill_type: Default::default(),
+        ..Default::default()
     });
 
     let json = serde_json::to_string(&layer).unwrap();
@@ -134,6 +138,7 @@ fn test_can_triangulate_valid() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     };
 
     assert!(area.can_triangulate(&projection));
@@ -147,6 +152,7 @@ fn test_can_triangulate_insufficient_points() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     };
 
     // Should return true as we don't consider < 3 points as a triangulation failure
@@ -170,6 +176,7 @@ mod geojson_tests {
             stroke: Stroke::new(2.0, Color32::from_rgb(0, 0, 255)),
             fill: Color32::from_rgba_unmultiplied(255, 0, 0, 128),
             fill_type: Default::default(),
+            ..Default::default()
         });
 
         let geojson_str = layer.to_geojson_str().unwrap();
@@ -193,6 +200,7 @@ mod geojson_tests {
             stroke: Default::default(),
             fill: Default::default(),
             fill_type: Default::default(),
+            ..Default::default()
         });
 
         let geojson_str = layer.to_geojson_str().unwrap();
@@ -217,6 +225,7 @@ mod geojson_tests {
             stroke: Default::default(),
             fill: Default::default(),
             fill_type: Default::default(),
+            ..Default::default()
         });
 
         let geojson_str = layer.to_geojson_str().unwrap();
@@ -242,6 +251,7 @@ fn ellipse_get_points_with_fixed_number() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     };
 
     let points = area.get_points(&projection);
@@ -262,6 +272,7 @@ fn ellipse_containment() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     };
 
     // Center is inside
@@ -292,6 +303,7 @@ fn find_node_at_on_segment() {
         stroke: Default::default(),
         fill: Default::default(),
         fill_type: Default::default(),
+        ..Default::default()
     });
 
     // Click exactly between p1 and p2

--- a/src/layers/area/types.rs
+++ b/src/layers/area/types.rs
@@ -59,6 +59,10 @@ pub enum FillType {
 /// A polygon area on the map.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Area {
+    /// The unique identifier of the area.
+    #[serde(default = "uuid::Uuid::new_v4")]
+    pub id: uuid::Uuid,
+
     /// The shape of the area.
     pub shape: AreaShape,
 
@@ -102,7 +106,30 @@ pub(crate) enum DraggedObject {
     },
 }
 
+impl Default for Area {
+    fn default() -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            shape: AreaShape::Polygon(Vec::new()),
+            stroke: Stroke::default(),
+            fill: Color32::TRANSPARENT,
+            fill_type: FillType::Solid,
+        }
+    }
+}
+
 impl Area {
+    /// Creates a new area with the given shape, stroke, fill, and a newly generated ID.
+    pub fn new(shape: AreaShape, stroke: Stroke, fill: Color32) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4(),
+            shape,
+            stroke,
+            fill,
+            fill_type: FillType::Solid,
+        }
+    }
+
     /// Checks if the area can be successfully triangulated.
     pub(crate) fn can_triangulate(&self, projection: &MapProjection) -> bool {
         let points = self.get_points(projection);

--- a/src/layers/geojson.rs
+++ b/src/layers/geojson.rs
@@ -48,6 +48,7 @@ impl From<Area> for Feature {
         let mut feature = Feature::default();
         let mut properties = Map::new();
         add_version_to_properties(&mut properties);
+        properties.insert("id".to_string(), JsonValue::String(area.id.to_string()));
 
         properties.insert(
             "stroke_color".to_string(),
@@ -250,7 +251,16 @@ impl TryFrom<Feature> for Area {
             FillType::Solid
         };
 
+        let id = feature
+            .properties
+            .as_ref()
+            .and_then(|props| props.get("id"))
+            .and_then(|val| val.as_str())
+            .and_then(|s| s.parse::<uuid::Uuid>().ok())
+            .unwrap_or_else(uuid::Uuid::new_v4);
+
         Ok(Area {
+            id,
             shape,
             stroke,
             fill,
@@ -312,6 +322,7 @@ impl From<Text> for Feature {
             coordinates: geojson::Position::from(vec![text.pos.lon, text.pos.lat]),
         });
         feature.geometry = Some(point);
+        properties.insert("id".to_string(), JsonValue::String(text.id.to_string()));
         properties.insert("text".to_string(), JsonValue::String(text.text));
         properties.insert("color".to_string(), JsonValue::String(text.color.to_hex()));
         properties.insert(
@@ -361,6 +372,12 @@ impl TryFrom<Feature> for Text {
 
         if let Some(properties) = feature.properties {
             check_version_from_properties(&properties);
+            if let Some(value) = properties.get("id")
+                && let Some(s) = value.as_str()
+                && let Ok(id) = s.parse::<uuid::Uuid>()
+            {
+                text.id = id;
+            }
             if let Some(value) = properties.get("text") {
                 if let Some(s) = value.as_str() {
                     text.text = s.to_string();

--- a/src/layers/svg.rs
+++ b/src/layers/svg.rs
@@ -11,6 +11,10 @@ use std::hash::{Hash, Hasher};
 /// An SVG element on the map.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SvgElement {
+    /// The unique identifier of the SVG element.
+    #[serde(default = "uuid::Uuid::new_v4")]
+    pub id: uuid::Uuid,
+
     /// The geographical position (longitude, latitude) of the SVG element.
     pub pos: GeoPos,
 
@@ -56,6 +60,7 @@ impl SvgElement {
     /// Creates a new SVG element.
     pub fn new(pos: GeoPos, text: impl Into<String>, metadata: impl Into<String>) -> Self {
         Self {
+            id: uuid::Uuid::new_v4(),
             pos,
             text: text.into(),
             metadata: metadata.into(),
@@ -74,6 +79,7 @@ impl SvgElement {
         metadata: impl Into<String>,
     ) -> Self {
         Self {
+            id: uuid::Uuid::new_v4(),
             pos: GeoPos { lon, lat },
             text: text.into(),
             metadata: metadata.into(),
@@ -82,6 +88,13 @@ impl SvgElement {
             draggable: false,
             anchor: default_anchor(),
         }
+    }
+
+    /// Sets the unique identifier of the SVG element.
+    #[must_use]
+    pub fn with_id(mut self, id: uuid::Uuid) -> Self {
+        self.id = id;
+        self
     }
 
     /// Sets whether the SVG element is scalable.
@@ -116,6 +129,8 @@ impl SvgElement {
 /// Information about a click on an SVG element.
 #[derive(Clone, Debug)]
 pub struct SvgClickEvent {
+    /// The ID of the clicked SVG element.
+    pub id: uuid::Uuid,
     /// The button that was clicked.
     pub button: PointerButton,
     /// The metadata of the clicked SVG element.
@@ -170,6 +185,25 @@ impl SvgLayer {
     /// Takes all click events from the layer, leaving it empty.
     pub fn take_events(&mut self) -> Vec<SvgClickEvent> {
         std::mem::take(&mut self.events)
+    }
+
+    /// Finds an SVG element by its ID.
+    pub fn find_element(&self, id: uuid::Uuid) -> Option<&SvgElement> {
+        self.elements.iter().find(|e| e.id == id)
+    }
+
+    /// Finds an SVG element by its ID and returns a mutable reference.
+    pub fn find_element_mut(&mut self, id: uuid::Uuid) -> Option<&mut SvgElement> {
+        self.elements.iter_mut().find(|e| e.id == id)
+    }
+
+    /// Removes an SVG element from the layer by its ID and returns it.
+    pub fn remove_element(&mut self, id: uuid::Uuid) -> Option<SvgElement> {
+        if let Some(pos) = self.elements.iter().position(|e| e.id == id) {
+            Some(self.elements.remove(pos))
+        } else {
+            None
+        }
     }
 }
 
@@ -262,6 +296,7 @@ impl Layer for SvgLayer {
                             };
 
                             self.events.push(SvgClickEvent {
+                                id: element.id,
                                 button,
                                 metadata: element.metadata.clone(),
                                 world_pos: projection.unproject(pointer_pos),
@@ -331,15 +366,13 @@ mod tests {
     #[test]
     fn svg_layer_serde() {
         let mut layer = SvgLayer::default();
-        layer.add_element(SvgElement {
-            pos: GeoPos { lon: 1.0, lat: 2.0 },
-            text: "<svg></svg>".to_string(),
-            metadata: "test metadata".to_string(),
-            scalable: false,
-            clickable: true,
-            draggable: false,
-            anchor: Pos2::new(0.5, 0.5),
-        });
+        layer.add_element(
+            SvgElement::new(GeoPos { lon: 1.0, lat: 2.0 }, "<svg></svg>", "test metadata")
+                .with_scalable(false)
+                .with_clickable(true)
+                .with_draggable(false)
+                .with_anchor(Pos2::new(0.5, 0.5)),
+        );
 
         let json = serde_json::to_string(&layer).unwrap();
         let deserialized: SvgLayer = serde_json::from_str(&json).unwrap();
@@ -367,20 +400,19 @@ mod tests {
         let deserialized: SvgLayer = serde_json::from_str(json).unwrap();
         assert!(deserialized.elements[0].clickable);
         assert!(!deserialized.elements[0].draggable);
+        assert_ne!(deserialized.elements[0].id, uuid::Uuid::nil());
     }
 
     #[test]
     fn svg_layer_clickable_false() {
         let mut layer = SvgLayer::default();
-        layer.add_element(SvgElement {
-            pos: GeoPos { lon: 1.0, lat: 2.0 },
-            text: "<svg></svg>".to_string(),
-            metadata: "test metadata".to_string(),
-            scalable: false,
-            clickable: false,
-            draggable: false,
-            anchor: default_anchor(),
-        });
+        layer.add_element(
+            SvgElement::new(GeoPos { lon: 1.0, lat: 2.0 }, "<svg></svg>", "test metadata")
+                .with_scalable(false)
+                .with_clickable(false)
+                .with_draggable(false)
+                .with_anchor(default_anchor()),
+        );
 
         let json = serde_json::to_string(&layer).unwrap();
         let deserialized: SvgLayer = serde_json::from_str(&json).unwrap();
@@ -390,15 +422,13 @@ mod tests {
     #[test]
     fn svg_layer_draggable_true() {
         let mut layer = SvgLayer::default();
-        layer.add_element(SvgElement {
-            pos: GeoPos { lon: 1.0, lat: 2.0 },
-            text: "<svg></svg>".to_string(),
-            metadata: "test metadata".to_string(),
-            scalable: false,
-            clickable: false,
-            draggable: true,
-            anchor: default_anchor(),
-        });
+        layer.add_element(
+            SvgElement::new(GeoPos { lon: 1.0, lat: 2.0 }, "<svg></svg>", "test metadata")
+                .with_scalable(false)
+                .with_clickable(false)
+                .with_draggable(true)
+                .with_anchor(default_anchor()),
+        );
 
         let json = serde_json::to_string(&layer).unwrap();
         let deserialized: SvgLayer = serde_json::from_str(&json).unwrap();

--- a/src/layers/text.rs
+++ b/src/layers/text.rs
@@ -26,6 +26,10 @@ impl Default for TextSize {
 /// A piece of text on the map.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Text {
+    /// The unique identifier of the text.
+    #[serde(default = "uuid::Uuid::new_v4")]
+    pub id: uuid::Uuid,
+
     /// The text to display.
     pub text: String,
 
@@ -47,6 +51,7 @@ pub struct Text {
 impl Default for Text {
     fn default() -> Self {
         Self {
+            id: uuid::Uuid::new_v4(),
             text: "New Text".to_string(),
             pos: GeoPos { lon: 0.0, lat: 0.0 }, // This will be updated on click.
             size: TextSize::default(),
@@ -59,8 +64,8 @@ impl Default for Text {
 /// The state of the text currently being edited or added.
 #[derive(Clone, Debug)]
 pub struct EditingText {
-    /// The index of the text being edited, if it's an existing one.
-    pub index: Option<usize>,
+    /// The unique identifier of the text being edited, if it's an existing one.
+    pub id: Option<uuid::Uuid>,
     /// The properties of the text being edited.
     pub properties: Text,
 }
@@ -116,28 +121,28 @@ impl Default for TextLayer {
 
 impl TextLayer {
     /// Starts editing an existing text element.
-    pub fn start_editing(&mut self, index: usize) {
-        if let Some(text) = self.texts.get(index) {
+    pub fn start_editing(&mut self, id: uuid::Uuid) {
+        if let Some(text) = self.texts.iter().find(|t| t.id == id) {
             self.editing = Some(EditingText {
-                index: Some(index),
+                id: Some(id),
                 properties: text.clone(),
             });
         }
     }
 
     /// Deletes a text element.
-    pub fn delete(&mut self, index: usize) {
-        if index < self.texts.len() {
-            self.texts.remove(index);
+    pub fn delete(&mut self, id: uuid::Uuid) {
+        if let Some(pos) = self.texts.iter().position(|t| t.id == id) {
+            self.texts.remove(pos);
         }
     }
 
     /// Saves the changes made in the editing dialog.
     pub fn commit_edit(&mut self) {
         if let Some(editing) = self.editing.take() {
-            if let Some(index) = editing.index {
+            if let Some(id) = editing.id {
                 // It's an existing text.
-                if let Some(text) = self.texts.get_mut(index) {
+                if let Some(text) = self.texts.iter_mut().find(|t| t.id == id) {
                     *text = editing.properties;
                 }
             } else {
@@ -150,6 +155,25 @@ impl TextLayer {
     /// Discards the changes made in the editing dialog.
     pub fn cancel_edit(&mut self) {
         self.editing = None;
+    }
+
+    /// Finds a text element by its ID.
+    pub fn find_text(&self, id: uuid::Uuid) -> Option<&Text> {
+        self.texts.iter().find(|t| t.id == id)
+    }
+
+    /// Finds a text element by its ID and returns a mutable reference.
+    pub fn find_text_mut(&mut self, id: uuid::Uuid) -> Option<&mut Text> {
+        self.texts.iter_mut().find(|t| t.id == id)
+    }
+
+    /// Removes a text element from the layer by its ID and returns it.
+    pub fn remove_text(&mut self, id: uuid::Uuid) -> Option<Text> {
+        if let Some(pos) = self.texts.iter().position(|t| t.id == id) {
+            Some(self.texts.remove(pos))
+        } else {
+            None
+        }
     }
 
     /// Serializes the layer to a `GeoJSON` `FeatureCollection`.
@@ -239,14 +263,17 @@ impl TextLayer {
             if let Some(pointer_pos) = response.interact_pointer_pos() {
                 if let Some(index) = self.find_text_at(pointer_pos, projection, &response.ctx) {
                     // Clicked on an existing text, start editing it.
-                    self.start_editing(index);
+                    if let Some(text) = self.texts.get(index) {
+                        self.start_editing(text.id);
+                    }
                 } else {
                     // Clicked on an empty spot, start adding a new text.
                     let geo_pos = projection.unproject(pointer_pos);
                     let mut properties = self.new_text_properties.clone();
+                    properties.id = uuid::Uuid::new_v4();
                     properties.pos = geo_pos;
                     self.editing = Some(EditingText {
-                        index: None,
+                        id: None,
                         properties,
                     });
                 }
@@ -370,12 +397,13 @@ mod tests {
             size: TextSize::Static(14.0),
             color: Color32::from_rgb(0, 0, 255),
             background: Color32::from_rgba_unmultiplied(255, 0, 0, 128),
+            ..Default::default()
         });
 
         let json = serde_json::to_string(&layer).unwrap();
 
-        // The serialized string should only contain texts.
-        assert!(json.contains(r##""texts":[{"text":"Hello","pos":{"lon":1.0,"lat":2.0},"size":{"Static":14.0},"color":"#0000ffff","background":"#ff000080""##));
+        // The serialized string should contain the text properties.
+        assert!(json.contains(r##""text":"Hello","pos":{"lon":1.0,"lat":2.0},"size":{"Static":14.0},"color":"#0000ffff","background":"#ff000080""##));
 
         // it should not contain skipped fields
         assert!(!json.contains("mode"));
@@ -399,10 +427,9 @@ mod tests {
         // Check that skipped fields have their values from the `default()` implementation.
         let default_layer = TextLayer::default();
         assert_eq!(deserialized.mode, default_layer.mode);
-        assert_eq!(
-            deserialized.new_text_properties,
-            default_layer.new_text_properties
-        );
+        let mut expected_properties = default_layer.new_text_properties.clone();
+        expected_properties.id = deserialized.new_text_properties.id;
+        assert_eq!(deserialized.new_text_properties, expected_properties);
         assert!(deserialized.editing.is_none());
         assert!(deserialized.dragged_text_index.is_none());
     }
@@ -420,6 +447,7 @@ mod tests {
                 size: TextSize::Static(14.0),
                 color: Color32::from_rgb(0, 0, 255),
                 background: Color32::from_rgba_unmultiplied(255, 0, 0, 128),
+                ..Default::default()
             });
 
             let geojson_str = layer.to_geojson_str().unwrap();


### PR DESCRIPTION
All layers should identity any reasonable object in them with an UUID value. Increasing the release version due to the fact that this is an breaking API change.